### PR TITLE
ssl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,27 @@ export default function () {
 ## Usage
 
 Check the [xk6-sql documentation](https://github.com/grafana/xk6-sql) on how to use this database driver.
+
+
+### TLS Support
+
+> [!IMPORTANT]
+>
+> TLS support has been adopted more or less unchanged from xk6-sql v0.4.1.
+> Refactoring is required.
+
+To enable TLS support, call `loadTLS` from the script, before calling `open`. [examples/example-tls.js](examples/example-tls.js) is an example.
+
+`loadTLS` accepts the following options:
+
+```javascript
+loadTLS({
+  enableTLS: true,
+  insecureSkipTLSverify: true,
+  minVersion: sql.TLS_1_2,
+  // Possible values: sql.TLS_1_0, sql.TLS_1_1, sql.TLS_1_2, sql.TLS_1_3
+  caCertFile: '/filepath/to/ca.pem',
+  clientCertFile: '/filepath/to/client-cert.pem',
+  clientKeyFile: '/filepath/to/client-key.pem',
+});
+```

--- a/examples/example-tls.js
+++ b/examples/example-tls.js
@@ -1,0 +1,41 @@
+// Adapted more or less unchanged from: https://github.com/surajvshankar/xk6-sql/blob/b72a1e0d2d05227eae60f0bb45ec01abb152653d/examples/mysql_secure_test.js
+// It will have to be refactored.
+
+import sql from "k6/x/sql";
+import { loadTLS, addTLS, default as driver } from "k6/x/sql/driver/mysql";
+
+loadTLS({
+  enableTLS: true,
+  insecureSkipTLSverify: true,
+  minVersion: driver.TLS_1_2,
+  // Possible values: sql.TLS_1_0, sql.TLS_1_1, sql.TLS_1_2, sql.TLS_1_3
+  caCertFile: "ca.pem",
+  clientCertFile: "client-cert.pem",
+  clientKeyFile: "client-key.pem",
+});
+
+const db = sql.open(driver, addTLS("root:password@tcp(localhost:3306)/mysql"));
+
+export function setup() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS keyvalues (
+      id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+      \`key\` VARCHAR(50) NOT NULL,
+      value VARCHAR(50) NULL
+    );
+  `);
+}
+
+export function teardown() {
+  db.close();
+}
+
+export default function () {
+  db.exec("INSERT INTO keyvalues (`key`, value) VALUES('plugin-name', 'k6-plugin-sql');");
+
+  let results = db.query("SELECT * FROM keyvalues WHERE `key` = ?;", "plugin-name");
+  for (const row of results) {
+    // Convert array of ASCII integers into strings. See https://github.com/grafana/xk6-sql/issues/12
+    console.log(`key: ${String.fromCharCode(...row.key)}, value: ${String.fromCharCode(...row.value)}`);
+  }
+}

--- a/examples/example-tls.js
+++ b/examples/example-tls.js
@@ -1,4 +1,4 @@
-// Adapted more or less unchanged from: https://github.com/surajvshankar/xk6-sql/blob/b72a1e0d2d05227eae60f0bb45ec01abb152653d/examples/mysql_secure_test.js
+// Adapted more or less unchanged from: https://github.com/grafana/xk6-sql/blob/v0.4.1/examples/mysql_secure_test.js
 // It will have to be refactored.
 
 import sql from "k6/x/sql";

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/grafana/sobek v0.0.0-20240927094302-19dd311f018f
 	github.com/grafana/xk6-sql v0.5.0-alpha.4
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.33.0
+	go.k6.io/k6 v0.54.0
 )
 
 require (
@@ -35,7 +37,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/pprof v0.0.0-20231127191134-f3a68a39ae15 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/grafana/sobek v0.0.0-20240927094302-19dd311f018f // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
@@ -67,7 +68,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.k6.io/k6 v0.54.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.29.0 // indirect

--- a/module.go
+++ b/module.go
@@ -1,0 +1,40 @@
+package mysql
+
+import (
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/js/modules"
+)
+
+// rootModule is the global module object type.
+type rootModule struct {
+	driverID *sobek.Symbol
+}
+
+var _ modules.Module = &rootModule{}
+
+// NewModuleInstance implements the modules.Module interface to return
+// a new instance for each VU.
+func (root *rootModule) NewModuleInstance(_ modules.VU) modules.Instance {
+	instance := &module{
+		exports: modules.Exports{
+			Default: root.driverID,
+			Named:   make(map[string]interface{}),
+		},
+	}
+
+	instance.tlsExports()
+
+	return instance
+}
+
+// module represents an instance of the JavaScript module for every VU.
+type module struct {
+	vu        modules.VU
+	tlsConfig TLSConfig
+	exports   modules.Exports
+}
+
+// Exports is representation of ESM exports of a module.
+func (mod *module) Exports() modules.Exports {
+	return mod.exports
+}

--- a/register.go
+++ b/register.go
@@ -3,11 +3,14 @@ package mysql
 
 import (
 	"github.com/grafana/xk6-sql/sql"
+	"go.k6.io/k6/js/modules"
 
 	// Blank import required for initialization of driver.
 	_ "github.com/go-sql-driver/mysql"
 )
 
 func init() {
-	sql.RegisterModule("mysql")
+	id := sql.RegisterDriver("mysql")
+
+	modules.Register("k6/x/sql/driver/mysql", &rootModule{driverID: id})
 }

--- a/tls.go
+++ b/tls.go
@@ -1,4 +1,4 @@
-// Adapted more or less unchanged from: https://github.com/surajvshankar/xk6-sql/blob/b72a1e0d2d05227eae60f0bb45ec01abb152653d/sql.go
+// Adapted more or less unchanged from: https://github.com/grafana/xk6-sql/blob/v0.4.1/sql.go
 // It will have to be refactored.
 
 package mysql

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,126 @@
+// Adapted more or less unchanged from: https://github.com/surajvshankar/xk6-sql/blob/b72a1e0d2d05227eae60f0bb45ec01abb152653d/sql.go
+// It will have to be refactored.
+
+package mysql
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/lib/netext"
+)
+
+// supportedTLSVersions is a map of TLS versions to their numeric values.
+var supportedTLSVersions = map[string]uint16{ //nolint: gochecknoglobals
+	netext.TLS_1_0: tls.VersionTLS10,
+	netext.TLS_1_1: tls.VersionTLS11,
+	netext.TLS_1_2: tls.VersionTLS12,
+	netext.TLS_1_3: tls.VersionTLS13,
+}
+
+// tlsExports add TLS releated exports to name dexports.
+func (mod *module) tlsExports() {
+	// TLS versions
+	mod.exports.Named["TLS_1_0"] = netext.TLS_1_0
+	mod.exports.Named["TLS_1_1"] = netext.TLS_1_1
+	mod.exports.Named["TLS_1_2"] = netext.TLS_1_2
+	mod.exports.Named["TLS_1_3"] = netext.TLS_1_3
+
+	// functions
+	mod.exports.Named["loadTLS"] = mod.LoadTLS
+	mod.exports.Named["addTLS"] = mod.AddTLS
+}
+
+const tlsConfigKey = "custom"
+
+// TLSConfig contains all the TLS configuration options passed between the JS and Go code.
+type TLSConfig struct {
+	EnableTLS             bool   `json:"enableTLS"`
+	InsecureSkipTLSverify bool   `json:"insecureSkipTLSverify"`
+	MinVersion            string `json:"minVersion"`
+	CAcertFile            string `json:"caCertFile"`
+	ClientCertFile        string `json:"clientCertFile"`
+	ClientKeyFile         string `json:"clientKeyFile"`
+}
+
+// LoadTLS loads the TLS configuration for the SQL module.
+func (mod *module) LoadTLS(params map[string]interface{}) error {
+	runtime := mod.vu.Runtime()
+	var tlsConfig *TLSConfig
+	if b, err := json.Marshal(params); err != nil {
+		common.Throw(runtime, err)
+	} else {
+		if err := json.Unmarshal(b, &tlsConfig); err != nil {
+			common.Throw(runtime, err)
+		}
+	}
+	if _, ok := supportedTLSVersions[tlsConfig.MinVersion]; !ok {
+		common.Throw(runtime, fmt.Errorf("unsupported TLS version: %s", tlsConfig.MinVersion))
+	}
+	mod.tlsConfig = *tlsConfig
+
+	if tlsConfig.EnableTLS {
+		if err := registerTLS(tlsConfigKey, mod.tlsConfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AddTLS add the "tls" connection parameter if TLS is enabled.
+func (mod *module) AddTLS(connectionString string) string {
+	if mod.tlsConfig.EnableTLS {
+		connectionString = prefixConnectionString(connectionString, tlsConfigKey)
+	}
+
+	return connectionString
+}
+
+// prefixConnectionString prefixes the connection string with the TLS configuration key.
+func prefixConnectionString(connectionString string, tlsConfigKey string) string {
+	tlsParam := fmt.Sprintf("tls=%s", tlsConfigKey)
+	if strings.Contains(connectionString, tlsParam) {
+		return connectionString
+	}
+	var separator string
+	if strings.Contains(connectionString, "?") {
+		separator = "&"
+	} else {
+		separator = "?"
+	}
+	return fmt.Sprintf("%s%s%s", connectionString, separator, tlsParam)
+}
+
+// registerTLS loads the ca-cert and registers the TLS configuration with the MySQL driver.
+func registerTLS(tlsConfigKey string, tlsConfig TLSConfig) error {
+	rootCAs := x509.NewCertPool()
+	pem, err := os.ReadFile(tlsConfig.CAcertFile) //nolint: forbidigo
+	if err != nil {
+		return err
+	}
+	if ok := rootCAs.AppendCertsFromPEM(pem); !ok {
+		return fmt.Errorf("failed to append PEM")
+	}
+
+	clientCerts := make([]tls.Certificate, 0, 1)
+	certs, err := tls.LoadX509KeyPair(tlsConfig.ClientCertFile, tlsConfig.ClientKeyFile)
+	if err != nil {
+		return err
+	}
+	clientCerts = append(clientCerts, certs)
+
+	mysqlTLSConfig := &tls.Config{
+		RootCAs:            rootCAs,
+		Certificates:       clientCerts,
+		MinVersion:         supportedTLSVersions[tlsConfig.MinVersion],
+		InsecureSkipVerify: tlsConfig.InsecureSkipTLSverify, // #nosec G402
+	}
+	return mysql.RegisterTLSConfig(tlsConfigKey, mysqlTLSConfig)
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,50 @@
+// Adapted more or less unchanged from: https://github.com/surajvshankar/xk6-sql/blob/b72a1e0d2d05227eae60f0bb45ec01abb152653d/sql_test.go#L99
+// It will have to be refactored.
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixConnectionString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		connectionString string
+		want             string
+	}{
+		{
+			name:             "HappyPath",
+			connectionString: "root:password@tcp(localhost:3306)/mysql",
+			want:             "root:password@tcp(localhost:3306)/mysql?tls=custom",
+		},
+		{
+			name:             "WithExistingParams",
+			connectionString: "root:password@tcp(localhost:3306)/mysql?param=value",
+			want:             "root:password@tcp(localhost:3306)/mysql?param=value&tls=custom",
+		},
+		{
+			name:             "WithExistingTLSparam",
+			connectionString: "root:password@tcp(localhost:3306)/mysql?tls=custom",
+			want:             "root:password@tcp(localhost:3306)/mysql?tls=custom",
+		},
+		{
+			name:             "WithExistingTLSparam",
+			connectionString: "root:password@tcp(localhost:3306)/mysql?tls=notcustom",
+			want:             "root:password@tcp(localhost:3306)/mysql?tls=notcustom&tls=custom",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := prefixConnectionString(tc.connectionString, "custom")
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,4 +1,4 @@
-// Adapted more or less unchanged from: https://github.com/surajvshankar/xk6-sql/blob/b72a1e0d2d05227eae60f0bb45ec01abb152653d/sql_test.go#L99
+// Adapted more or less unchanged from: https://github.com/grafana/xk6-sql/blob/v0.4.1/sql_test.go#L99
 // It will have to be refactored.
 
 package mysql


### PR DESCRIPTION
xk6-sql v0.4.1 includes a MySQL specific SSL support. The implementation moved to the xk6-sql-driver-mysql extension "as is".

