### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/xk6-sql-driver-mysql
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.25.10
 
 require (
 	github.com/go-sql-driver/mysql v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/xk6-sql-driver-mysql
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.3
 
 require (
 	github.com/go-sql-driver/mysql v1.10.0


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.