### PR TITLE
fix(deps): update module github.com/grafana/xk6-sql to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.11
 require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
-	github.com/grafana/xk6-sql v1.1.1
+	github.com/grafana/xk6-sql v1.2.0
 	github.com/stretchr/testify v1.11.1
 	go.k6.io/k6/v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b h1:mM/qn1luOrRZHT3G+
 github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b/go.mod h1:8pB+ag4SAbqtDxh1LNTeUI62/5f8mmEACImwbDHoUC0=
 github.com/grafana/xk6-dashboard-assets v0.1.2 h1:n2wqytPICn2ZYsKa9HE6GlvFXk+WjByMfT4eM+ms3gE=
 github.com/grafana/xk6-dashboard-assets v0.1.2/go.mod h1:SeoRjvmFF8UhLIFDfvjqqwBtE8MtaIPYIDWqVJZEHDo=
-github.com/grafana/xk6-sql v1.1.1 h1:sZk3eMCz3tEWhnLIkC37ShyeUdrqZ/mvJDVKzxYxA/0=
-github.com/grafana/xk6-sql v1.1.1/go.mod h1:gHnLJTOG/eBmi5oAXAHHnaHP87u8uAipPxebk9aFvGU=
+github.com/grafana/xk6-sql v1.2.0 h1:JBlpnMgGGu72V/cSVR3HInrMRs+kc4GP3LX6zhdxbjg=
+github.com/grafana/xk6-sql v1.2.0/go.mod h1:Dj2S/TauS08RxE6BzOucH5J6MJkdziYhAMglPRb3BWM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=


### PR DESCRIPTION
Bumps `github.com/grafana/xk6-sql` to **v1.2.0**, which requires **k6 v2.0.0** (stable).

As a result `go get` pulls the indirect `go.k6.io/k6/v2` from `v2.0.0-rc1` to `v2.0.0` — aligning this driver with the k6 v2 stable line. No tidy gymnastics needed; `go get` handles the transitive bump.

Manual equivalent of the Renovate update (cut ahead of the monthly schedule to unblock the k6 v2 driver releases).